### PR TITLE
Refactored platform detection to utilze Vagrant::Util::Platform class

### DIFF
--- a/etc/vagrant.config.yaml
+++ b/etc/vagrant.config.yaml
@@ -32,9 +32,9 @@ settings:
       - ssh
   # Platform detection
   platform:
-    is_windows: "<%= RbConfig::CONFIG['host_os'] =~ /mingw32/ ? true : false %>"
-    is_osx: "<%= RbConfig::CONFIG['host_os'] =~ /darwin/ ? true : false %>"
-    is_linux: "<%= RbConfig::CONFIG['host_os'] =~ /linux/ ? true : false %>"
+    is_windows: <%= Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.cygwin? %>
+    is_osx: <%= Vagrant::Util::Platform.darwin? %>
+    is_linux: <%= Vagrant::Util::Platform.linux? %>
   project:
     editor: 
       path: "C:\\progra~1\\SUBLIM~1\\subl.exe"


### PR DESCRIPTION
Platform detection logic was producing false positives. 

i.e.

Although $platform.is_windows was evaluating to 'false' on linux systems, running tests like if $platform.is_windows resulted in a *true* outcome, as 'false' is inherently a String class, not boolean; thus evaluating to a *true* condition.